### PR TITLE
[2.0.0-rc.1 build 1] Remove run_constrained that prevents co-installation with openforcefields

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . -vv --no-deps"
 
 requirements:
@@ -21,8 +21,6 @@ requirements:
   run:
     - python >=3.6
     - setuptools
-  run_constrained:
-    - openforcefields ==9999999999
 
 test:
   imports:


### PR DESCRIPTION
The benchmarking stack is pinned to `openforcefield=0.8.4`, which requires `openforcefields`. Now that we're looking to include the sage release candidate in benchmarking season 1, we need to include `openff-forcefields` in that same environment. However, the `run_constrained` pin in this recipe prevents installation alongside `openforcefields`. 

While it's pretty important to keep `openforcefield` and `openff-toolkit` from being installed simultaneously, there's far less potential harm in having `openforcefields` and `openff-forcefields` installed together. Because of the entry points these two can happily coexist, and it's no problem if there are multiple FF files found with the same filename, since they're guaranteed to be identical.

So, I think the simplest thing to do to unblock the benchmarking effort is to just remove this pin. 

CC @dotsdl - I think this is the cleanest way to remove the blocker we encountered today. Unless you can think of anything simpler tomorrow morning, then we should go ahead with this. 

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
